### PR TITLE
fix relative import error

### DIFF
--- a/md_metayaml.py
+++ b/md_metayaml.py
@@ -1,7 +1,7 @@
 from pelican import signals
 from pelican.readers import MarkdownReader
 
-from .markdown_metayaml.meta_yaml import MetaYamlExtension
+from markdown_metayaml.meta_yaml import MetaYamlExtension
 
 class MarkdownYAMLReader(MarkdownReader):
     """Reader for Markdown files with YAML metadata"""


### PR DESCRIPTION
This fixes a ValueError on import with python 2.7.6

    from .markdown_metayaml.meta_yaml import MetaYamlExtension
    ValueError: Attempted relative import in non-package

If the relative import is working for others then perhaps I just need some guidance with usage. Relevant pelicanconfig.py is https://github.com/n-west/cgran-frontend/blob/master/pelicanconf.py#L31